### PR TITLE
Fix horizontal scrolling on Chrome Linux/Windows

### DIFF
--- a/src/app/components/home.js
+++ b/src/app/components/home.js
@@ -61,6 +61,8 @@ class Home extends Component {
 
         largeHeader = document.getElementById('particles');
         largeHeader.style.height = `${height}px`;
+        // Make sure not to widen the body because of the header.
+        largeHeader.style.overflow = 'hidden';
 
         canvas = document.getElementById('demo-canvas');
         canvas.width = width;


### PR DESCRIPTION
On Chrome Linux/Windows the window.innerWidth has the client width + the width of the horizontal scrollbar. Setting that as the width for the canvas makes for a weird tiny horizontal scrolling.

https://pasteboard.co/ITzT5pl.png